### PR TITLE
Pet buff fixes and macro icon modification

### DIFF
--- a/Src/Cache/MemberCache.lua
+++ b/Src/Cache/MemberCache.lua
@@ -116,7 +116,7 @@ local function bomGet5manPartyMembers(player_member)
     member = bomGetMember("partypet" .. groupIndex, nil, nil, true)
 
     if member then
-      member.group = 9
+      member.owner = bomGetMember("party" .. groupIndex)
       member.class = "pet"
       tinsert(party, member)
     end
@@ -128,7 +128,7 @@ local function bomGet5manPartyMembers(player_member)
   member = bomGetMember("pet", nil, nil, true)
 
   if member then
-    member.group = 9
+    member.owner = bomGetMember("player")
     member.class = "pet"
     tinsert(party, member)
   end
@@ -164,9 +164,9 @@ local function bomGet40manRaidMembers(player_member)
       end
       tinsert(party, member)
 
-      member = bomGetMember("raidpet" .. raid_index, nil, nil, true)
+      member = bomGetMember("raidpet" .. raid_index, name_group, nil, true)
       if member then
-        member.group = 9
+        member.owner = bomGetMember("raid" .. raid_index, name_group, name_role)
         member.class = "pet"
         tinsert(party, member)
       end

--- a/Src/Const/Const.lua
+++ b/Src/Const/Const.lua
@@ -7,7 +7,7 @@ constModule.TOC_VERSION = GetAddOnMetadata(TOCNAME, "Version") --used for displa
 constModule.TOC_TITLE = GetAddOnMetadata(TOCNAME, "Title") -- Longer title like "Buffomat Classic TBC"
 constModule.SHORT_TITLE = "Buffomat"
 constModule.MACRO_ICON = "INV_MISC_QUESTIONMARK"
-constModule.MACRO_ICON_DISABLED = "INV_MISC_QUESTIONMARK"
+constModule.MACRO_ICON_DISABLED = "Ability_Druid_DemoralizingRoar"
 constModule.BOM_BEAR_ICON_FULLPATH = "Interface\\ICONS\\Ability_Druid_ChallangingRoar" -- Icon picture used in window title, in the minimap icon, etc
 
 constModule.ICON_FORMAT = "|T%s:0:0:0:0:64:64:4:60:4:60|t"

--- a/Src/TaskScan.lua
+++ b/Src/TaskScan.lua
@@ -316,7 +316,7 @@ local function bomUpdateSpellTargets(party, spell, playerMember, someoneIsDead)
       if member.isDead
               and not member.hasResurrection
               and member.isConnected
-              and member.group ~= 9
+              and member.class ~= "pet"
               and (not BOM.SharedState.SameZone or member.isSameZone) then
         tinsert(spell.NeedMember, member)
       end
@@ -448,7 +448,7 @@ local function bomUpdateSpellTargets(party, spell, playerMember, someoneIsDead)
       if member.NeedBuff
               and ok
               and member.isConnected
-              and (not BOM.SharedState.SameZone or member.isSameZone) then
+              and (not BOM.SharedState.SameZone or (member.isSameZone or member.class == "pet" and member.owner.isSameZone)) then
         local found = false
         local member_buff = member.buffs[spell.ConfigID]
 


### PR DESCRIPTION
Pet zone is no longer unknown (uses owner's zone). Pets are considered to be in the correct raid groups (used by Raid groups watch settings). These changes should fix #38. Previously pet buffing would not work at all if "Scan members in same zone" is enabled (pet zone was always nil), and it would not work in raids because pets were considered to be in group 9 (failed in src/TaskScan.lua line 429).
NOTE: I'm unsure if group 9 is used by any other logic, but if so then this may introduce unintended behaviour.

Re-added the DISABLED macro icon so there's a visual difference between these two states: "Unable to buff due to combat" and "unable to buff because there is nothing to do".
The question mark icon is only visible when there is something to do but combat is preventing it. Otherwise the icon will be the specific buff or the DISABLED icon (demo roar). I think this behaviour is an improvement because the (ugly) question mark icon is only seen when there's an actual issue: combat lockdown interrupting buffs. Of course the icon still cannot change from DISABLED to QUESTION_MARK in combat.