### PR TITLE
fix copy/paste error

### DIFF
--- a/Src/Ui/BuffRow.lua
+++ b/Src/Ui/BuffRow.lua
@@ -127,7 +127,7 @@ function buffRowClass:CreateOffhandToggle(tooltip)
   self.OffHand:SetOnClick(BOM.MyButtonOnClick)
   BOM.Tool.Tooltip(self.OffHand, tooltip)
 
-  return self.MainHand
+  return self.OffHand
 end
 
 ---@param tooltip string


### PR DESCRIPTION
Fixes a copy paste error in BuffRow.lua that results in cycling in-game errors.

function should return `self.OffHand`, but returns `self.MainHand`