### PR TITLE
Fix for macro test being continually reset

### DIFF
--- a/Src/Task/TaskList.lua
+++ b/Src/Task/TaskList.lua
@@ -231,7 +231,6 @@ function taskListClass:CastButtonText(t, enable)
   if enable then
     BomC_ListTab_Button:Enable()
   else
-    taskListModule:WipeMacro(nil)
     BomC_ListTab_Button:Disable()
   end
 


### PR DESCRIPTION
Fixes the issue where all macros are constantly reset while BoM is active.

WipeMacro was being called when disabling the ListTab button, and it does not respect the MacroWindow checks.

Fixes #128 