### PR TITLE
Fix error with buffs that have no "expire"

### DIFF
--- a/Src/Classes/Unit.lua
+++ b/Src/Classes/Unit.lua
@@ -72,15 +72,15 @@ function unitModule:UnitAura(unitId, buffIndex, filter)
 
       if duration > 0 and (expirationTime == nil or expirationTime == 0) then
         local destName = UnitFullName(unitId) ---@type string
-        local buffOnPlayer = partyModule.unitAurasLastUpdated[destName]
+        local lastUpdatedTime = partyModule.unitAurasLastUpdated[destName]
 
-        if buffOnPlayer and buffOnPlayer[name] then
-          expirationTime = (buffOnPlayer[name] or 0) + duration
+        if lastUpdatedTime then
+          expirationTime = lastUpdatedTime + duration
 
           local now = GetTime()
 
           if expirationTime <= now then
-            buffOnPlayer[name] = now
+            partyModule.unitAurasLastUpdated[destName] = now
             expirationTime = now + duration
           end
         end


### PR DESCRIPTION
Something about BGs in SoD 1.15.5 means this code runs and it causes errors.


```
BuffomatClassic/Src/Classes/Unit.lua:77: attempt to index local 'buffOnPlayer' (a number value)
[string "@BuffomatClassic/Src/Classes/Unit.lua"]:77: in function `UnitAura'
[string "@BuffomatClassic/Src/Classes/Unit.lua"]:143: in function `ForceUpdateBuffs'
[string "@BuffomatClassic/Src/Classes/Unit.lua"]:290: in function `UpdateBuffs'
[string "@BuffomatClassic/Src/Classes/Party.lua"]:332: in function `GetParty'
[string "@BuffomatClassic/Src/Task/TaskScan.lua"]:1662: in function `RotateInvalidatedGroup_GetGroup'
[string "@BuffomatClassic/Src/Task/TaskScan.lua"]:1707: in function `UpdateScan_PreCheck'
[string "@BuffomatClassic/Src/Task/TaskScan.lua"]:1762: in function `ScanTasks'
[string "@BuffomatClassic/Src/Buffomat.lua"]:624: in function `Entry'
[string "@BuffomatClassic/Src/Toolbox/Toolbox.lua"]:83: in function <...rfaceBuffomatClassic/Src/Toolbox/Toolbox.lua:81>

Locals:
self = <table> {
}
unitId = "raid9"
buffIndex = 1
filter = "HELPFUL"
name = "Trueshot Aura"
icon = 132329
count = 0
debuffType = nil
duration = 1800
expirationTime = 0
source = "player"
isStealable = false
nameplateShowPersonal = false
spellId = 20906
canApplyAura = true
isBossDebuff = false
castByPlayer = true
nameplateShowAll = false
timeMod = 1
destName = "Dingun"
buffOnPlayer = 2432621.681000
(*temporary) = "Dingun"
(*temporary) = "attempt to index local 'buffOnPlayer' (a number value)"
allBuffsModule = <table> {
 TEN_MINUTES = 600
 FROST_CLASSES = <table> {
 }
 RESURRECT_CLASSES = <table> {
 }
 SHADOW_CLASSES = <table> {
 }
 cancelForm = <table> {
 }
 BOM_NO_CLASSES = <table> {
 }
 FIFTEEN_MINUTES = 900
 FIRE_CLASSES = <table> {
 }
 TWO_MINUTES = 120
 allSpellIds = <table> {
 }
 MINUTE = 60
 HOUR = 3600
 ALL_CLASSES = <table> {
 }
 allBuffs = <table> {
 }
 FIVE_MINUTES = 300
 CrusaderAuraSpell = <table> {
 }
 buffCategories = <table> {
 }
 TWENTY_MINUTES = 1200
 SPELL_CLASSES = <table> {
 }
 enchantToSpellLookup = <table> {
 }
 spellToSpellLookup = <table> {
 }
 HALF_AN_HOUR = 1800
 MANA_CLASSES = <table> {
 }
 buffFromSpellIdLookup = <table> {
 }
 itemListSpellLookup = <table> {
 }
 selectedBuffs = <table> {
 }
 MELEE_CLASSES = <table> {
 }
 selectedBuffsSpellIds = <table> {
 }
 spellIdIsSingleLookup = <table> {
 }
 spellIdtoBuffId = <table> {
 }
 PHYSICAL_CLASSES = <table> {
 }
}
buffomatModule = <table> {
 currentProfileName = "battleground"
 fpsCheck = 2432622382.594500
 BOM_THROTTLE_SLOWER_HARDWARE_TIMER_LIMIT = 2
 taskRescanRequestedBy = <table> {
 }
 slowerhardwareUpdateTimerLimit = 1.500000
 lastUpdateTimestamp = 2432622.381000
 autoHelper = "open"
 updateTimerLimit = 0.500000
 currentProfile = <table> {
 }
 optionsFrames = <table> {
 }
 character = <table> {
 }
 SPELLS_TAB_UPDATE_DELAY = 2
 lastModifierKeyState = false
 shared = <table> {
 }
 slowCount = 0
 lastSpellsTabUpdate = 2432621.881000
 BOM_THROTTLE_TIMER_LIMIT = 1
}
partyModule = <table> {
 theParty = <table> {
 }
 unitAurasLastUpdated = <table> {
 }
 partyCacheInvalidation = <table> {
 }
 playerManaLimit = 3615
 ALL_INVALID_GROUPS = <table> {
 }
 playerMana = 1776
 itemListTarget = <table> {
 }
}
```